### PR TITLE
V.1.0.4.1

### DIFF
--- a/WF.MinifyBundler/WF.MinifyBundler.csproj
+++ b/WF.MinifyBundler/WF.MinifyBundler.csproj
@@ -8,7 +8,7 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <IsPackable>true</IsPackable>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>1.0.4</Version>
+        <Version>1.0.4.1</Version>
         <Title>WF.MinifyBundler</Title>
         <Authors>WebFox</Authors>
         <Description>Bundle your javascript and css files easy</Description>

--- a/WF.MinifyBundler/build/WF.MinifyBundler.targets
+++ b/WF.MinifyBundler/build/WF.MinifyBundler.targets
@@ -13,7 +13,7 @@
         <ItemGroup>
             <None Remove="@(GeneratedFiles)"/>
             <_NewCompiledFiles Include="@(GeneratedFiles)" Exclude="@(Content)"/>
-            <Content Include="@(_NewCompiledFile)"/>
+            <Content Include="@(_NewCompiledFiles )"/>
         </ItemGroup>
     </Target>
 


### PR DESCRIPTION
missed an s in the content include